### PR TITLE
Rewrite M18/M84 as they cause the printer to crash too.

### DIFF
--- a/octoprint_fixcbdfirmware/__init__.py
+++ b/octoprint_fixcbdfirmware/__init__.py
@@ -17,14 +17,11 @@ class FixCBDFirmwarePlugin(octoprint.plugin.OctoPrintPlugin):
 			# firmware chokes on N parameters with M110, fix that
 			self._log_replacement(cmd, "M110")
 			return "M110"
-		elif gcode == "G28":
-			# firmware chokes on X, Y & probably Z parameter on G28, rewrite to X0, Y0, Z0
+		elif gcode in ["G28", "M18", "M84"]:
+			# firmware chokes on X, Y & probably Z parameter, rewrite to X0, Y0, Z0
 			rewritten = self.REGEX_XYZ0.sub("\g<axis>0 ", cmd).strip()
 			self._log_replacement(cmd, rewritten)
 			return rewritten
-                elif gcode == "M84" or gcode == "M18":
-                        # firmware chokes on X, Y, E & probably Z parameter on M84 and M18, fix that.
-                        return gcode
 
 	def rewrite_received(self, comm_instance, line, *args, **kwargs):
 		line = self._rewrite_wait_to_busy(line)

--- a/octoprint_fixcbdfirmware/__init__.py
+++ b/octoprint_fixcbdfirmware/__init__.py
@@ -22,6 +22,9 @@ class FixCBDFirmwarePlugin(octoprint.plugin.OctoPrintPlugin):
 			rewritten = self.REGEX_XYZ0.sub("\g<axis>0 ", cmd).strip()
 			self._log_replacement(cmd, rewritten)
 			return rewritten
+                elif gcode == "M84" or gcode == "M18":
+                        # firmware chokes on X, Y, E & probably Z parameter on M84 and M18, fix that.
+                        return gcode
 
 	def rewrite_received(self, comm_instance, line, *args, **kwargs):
 		line = self._rewrite_wait_to_busy(line)


### PR DESCRIPTION
Hi, obligatory I have no idea what I'm doing.

I have been helping a fellow that has a Tronxy XY-2 Pro that is running the dreaded CBD firmware, this plugin mostly fixed it for him, however he found that at the end of every print, octoprint would loose connection to the printer, saying that the printer keeps requesting line X again and again, communication stuck.

After some investigation, he discovered that M84 was the issue. We hopped into the Octoprint console and ran `M84 X Y E` and the connection dropped. We also tried `M84 X`, `M84 Y`, `M84 E`, `M18 X Y E` and they all caused the connection to drop too. As such I think the only solution is truncating all M84 and M18 calls, which is what I have done in this patch. He has tested the patch and confirmed that it has resolved the issue for him.